### PR TITLE
Added FoxholeHQ.com

### DIFF
--- a/Projects.md
+++ b/Projects.md
@@ -63,6 +63,10 @@ https://foxholehq.net/factory
 A visual map of Foxhole to securely store stockpile names & codes to make sharing it with your friends, clans, coalitions easier!  
 https://foxholehq.net/stockpile
 
+#### Multi-tool Website | FoxholeHQ.com:  
+Foxhole tools such as Logistic Calculator, Interactive Map with filtering and private regiment markers, Foxhole 3D Model Viewer, and Chrome/Firefox Live War Extension!
+https://foxholehq.com/
+
 # Artillery Calculators
 
 #### Arty Spotter:  


### PR DESCRIPTION
Added FoxholeHQ.com to the list of available projects for Foxhole, I added .com to differentiate between FoxholeHQ.net and FoxholeHQ.com.